### PR TITLE
Using originalUrl instead or url

### DIFF
--- a/lib/shield/policyShield.js
+++ b/lib/shield/policyShield.js
@@ -37,7 +37,7 @@ util.inherits(PolicyShield, Shield);
  */
 PolicyShield.prototype.evaluate = function (request, response, agent) {
     var params = {
-        resources: [request.url],
+        resources: [request.originalUrl || request.url],
         application: this.applicationName,
         subject: {}
     };


### PR DESCRIPTION
This change is here to keep the compatibility with the middleware which rewrites the original request.url
Background: http://expressjs.com/api.html#req.originalUrl