### PR TITLE
Test with AM 6.0

### DIFF
--- a/src/amclient/am-client.ts
+++ b/src/amclient/am-client.ts
@@ -65,7 +65,8 @@ export class AmClient {
         headers: {
           host: this.hostname,
           'X-OpenAM-Username': username,
-          'X-OpenAM-Password': password
+          'X-OpenAM-Password': password,
+          'Accept-API-Version': 'resource=1.0'
         },
         params: { realm, authIndexType, authIndexValue, noSession }
       })

--- a/src/policyagent/policy-agent.ts
+++ b/src/policyagent/policy-agent.ts
@@ -136,10 +136,10 @@ export class PolicyAgent extends EventEmitter {
         return await request();
       } catch (err) {
         attemptCount++;
-        this.logger.debug(`PolicyAgent: ${name} - caught error ${err.message}`, err);
+        this.logger.debug(`PolicyAgent: ${name} - caught error ${err.message}`);
         this.logger.info(`PolicyAgent: ${name} - retrying request - attempt ${attemptCount} of ${attemptLimit}`);
         // renew agent session on 401 response
-        if (err instanceof InvalidSessionError || err.statusCode === 401) {
+        if (err instanceof InvalidSessionError || err.statusCode === 401 || err.code === 401 || (err.response && err.response.status === 401)) {
           this.agentSession = this.authenticateAgent();
           await this.agentSession;
         } else if (attemptCount === attemptLimit) {

--- a/src/policyagent/policy-agent.ts
+++ b/src/policyagent/policy-agent.ts
@@ -139,11 +139,12 @@ export class PolicyAgent extends EventEmitter {
         this.logger.debug(`PolicyAgent: ${name} - caught error ${err.message}`);
         this.logger.info(`PolicyAgent: ${name} - retrying request - attempt ${attemptCount} of ${attemptLimit}`);
         // renew agent session on 401 response
-        if (err instanceof InvalidSessionError || err.statusCode === 401 || err.code === 401 || (err.response && err.response.status === 401)) {
+        if (err instanceof InvalidSessionError || err.statusCode === 401 || err.code === 401 ||
+           (err.response && err.response.status === 401)) {
           this.agentSession = this.authenticateAgent();
           await this.agentSession;
         } else if (attemptCount === attemptLimit) {
-          throw err
+          throw err;
         }
       }
     }

--- a/src/policyagent/policy-agent.ts
+++ b/src/policyagent/policy-agent.ts
@@ -142,6 +142,8 @@ export class PolicyAgent extends EventEmitter {
         if (err instanceof InvalidSessionError || err.statusCode === 401) {
           this.agentSession = this.authenticateAgent();
           await this.agentSession;
+        } else if (attemptCount === attemptLimit) {
+          throw err
         }
       }
     }


### PR DESCRIPTION
The API version must be set and the exception in `reRequest` is propagated to caller. I need to test what happens if the token is expired `status 401` 