### PR TITLE
support protocol from upstream proxy (fixes #36)

### DIFF
--- a/src/utils/http-utils.spec.ts
+++ b/src/utils/http-utils.spec.ts
@@ -1,0 +1,45 @@
+import { IncomingMessage, ServerResponse } from 'http';
+
+import { getProtocol } from './http-utils';
+
+describe('http-utils', () => {
+  let req: IncomingMessage;
+
+  describe('getProtocol()', () => {
+    it('should use https from the express protocol if present', () => {
+      req = <any>{ url: 'test-login-url', headers: {}, protocol: 'https' };
+
+      expect(getProtocol(req)).toEqual('https');
+    });
+
+    it('should use http from the express protocol if present', () => {
+      req = <any>{ url: 'https://test-login-url', headers: {}, protocol: 'http' };
+
+      expect(getProtocol(req)).toEqual('http');
+    });
+
+    it('should use https from the x-forwarded-proto header if present', () => {
+      req = <any>{ url: 'test-login-url', headers: { 'x-forwarded-proto': 'https' } };
+
+      expect(getProtocol(req)).toEqual('https');
+    });
+
+    it('should use http from the x-forwarded-proto header if present', () => {
+      req = <any>{ url: 'https://test-login-url', headers: { 'x-forwarded-proto': 'http' } };
+
+      expect(getProtocol(req)).toEqual('http');
+    });
+
+    it('should use the url protocol if present', () => {
+      req = <any>{ url: 'https://test-login-url', headers: {} };
+
+      expect(getProtocol(req)).toEqual('https');
+    });
+
+    it('should use http if no evidence of https', () => {
+      req = <any>{ url: 'test-login-url', headers: {} };
+
+      expect(getProtocol(req)).toEqual('http');
+    });
+  });
+});

--- a/src/utils/http-utils.ts
+++ b/src/utils/http-utils.ts
@@ -26,5 +26,7 @@ export function baseUrl(req: IncomingMessage): string {
  * Returns the request scheme - "http" or "https"
  */
 export function getProtocol(req: IncomingMessage): 'http' | 'https' {
-  return req.url.startsWith('https') ? 'https' : 'http';
+  return req[ 'protocol' ]
+    ?? req.headers[ 'x-forwarded-proto' ]
+    ?? (req.url.startsWith('https') ? 'https' : 'http');
 }


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/ForgeRock/node-openam-agent/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] A PR for the wiki has been submitted to https://github.com/ForgeRock/node-openam-agent.wiki.git as needed (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?

When `x-forwarded-proto` header is set to `https`, the goto URL is set to `http://...`

Issue Number: #36 


## What is the new behavior?

Correct behaviour behind a proxy that is handling the https.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

